### PR TITLE
Harden CSP: remove unsafe-inline, deny by default

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,7 @@
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), camera=(), microphone=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' https://webmention.io https://api.github.com; font-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-OdbZQZXbUBJu+W/zfmrjzmW4F+LQcj1o7B14GjBDndk=' 'sha256-cLylwyRMqj4vcaurpixDxy1sxWPrN0XiZEslSDEWqqk='; style-src 'self'; img-src 'self' https: data:; connect-src 'self' https://webmention.io https://api.github.com; font-src 'self'; manifest-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'


### PR DESCRIPTION
- Change default-src from 'self' to 'none' (explicit allowlisting)
- Replace 'unsafe-inline' in script-src with SHA-256 hashes of the two actual inline scripts (ThemeProvider FOUC prevention and BlogPost scroll-to-top button)
- Add 'wasm-unsafe-eval' for pagefind search WebAssembly
- Remove 'unsafe-inline' from style-src (site has zero inline styles)
- Add manifest-src 'self' for webmanifest
- Restore X-Frame-Options header (was dropped in previous edit)

The hashes are computed from the built output and verified to be deterministic across rebuilds. They will need updating if the inline script content in ThemeProvider.astro or BlogPost.astro changes.

https://claude.ai/code/session_012hc7KfiGwt5rDUXZEUpDua