### PR TITLE
Develop - fix post install script and instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,11 +120,13 @@ The site uses the following Astro integrations and plugins:
 **Astro Integrations:**
 - `@astrojs/mdx`: MDX support
 - `@astrojs/sitemap`: Automatic sitemap generation
-- `@astrojs/rss` (used as a library in RSS endpoint files, not as an Astro integration): RSS feed generation
 - `astro-expressive-code`: Code syntax highlighting (Dracula dark, GitHub Light themes)
 - `astro-icon`: Icon components (MDI icons)
 - `astro-robots-txt`: Robots.txt generation
 - `astro-webmanifest`: Web manifest for PWA
+
+**Libraries (not integrations):**
+- `@astrojs/rss`: RSS feed generation via endpoint files (`src/pages/rss.xml.ts`, `src/pages/notes/rss.xml.ts`)
 
 **Remark Plugins:**
 - `remark-directive`: Handle ::: directives in markdown

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"version": "6.11.0",
 	"private": false,
 	"scripts": {
-		"postinstall": "npm rebuild sharp --force",
+		"postinstall": "pnpm rebuild sharp",
 		"dev": "astro dev",
 		"start": "astro dev",
 		"build": "astro build",


### PR DESCRIPTION
This pull request makes a couple of small but useful improvements to the project documentation and build process. The most notable changes are clarifying the use of the `@astrojs/rss` package in `.github/copilot-instructions.md` and updating the `postinstall` script in `package.json` to use `pnpm` instead of `npm`.

Build process update:

* Changed the `postinstall` script in `package.json` to use `pnpm rebuild sharp` instead of `npm rebuild sharp --force`, aligning with the project's package manager.

Documentation clarification:

* Updated `.github/copilot-instructions.md` to clearly distinguish `@astrojs/rss` as a library (used in endpoint files) rather than an Astro integration, and specified its usage locations.