### PR TITLE
fix: remove non-existent ci label from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
     target-branch: 'develop'
     labels:
       - 'dependencies'
-      - 'ci'
     groups:
       actions:
         patterns:


### PR DESCRIPTION
The 'ci' label referenced in the github-actions update block does not exist in the repository, causing Dependabot to error. Remove it so Dependabot can apply labels successfully.

https://claude.ai/code/session_01PDTxkUbWbjsu7boXnCaHim