### PR TITLE
rename repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance for Claude Code when working in this repository.
 
 Personal infosec blog for **Jonathan Strong** (`jonathanstrong.org`), migrated from Jekyll/GitHub Pages to **Astro** using the [astro-theme-cactus](https://github.com/chrismwilliams/astro-theme-cactus) template, deployed on **Cloudflare Pages**.
 
+**Repository:** `mrjonstrong/website` (renamed from `mrjonstrong/mrjonstrong.github.io` to prevent GitHub Pages from auto-building)
+
 ## Commands
 
 ```bash
@@ -102,6 +104,7 @@ CI runs the same `pnpm check` and `pnpm build` commands used locally. The `postb
 
 ## Cloudflare Pages Setup
 
+- **Repository:** `mrjonstrong/website`
 - **Production branch:** `main` (deployed to jonathanstrong.org)
 - **Preview branches:** Feature branches get automatic preview deployments
 - **Build command:** `pnpm build`


### PR DESCRIPTION
This pull request updates the repository documentation in `CLAUDE.md` to reflect the migration and renaming of the repository, ensuring that both general and Cloudflare Pages setup sections reference the correct repository name.

Repository migration and naming:

* Updated the documentation to state that the repository has been renamed from `mrjonstrong/mrjonstrong.github.io` to `mrjonstrong/website` to prevent GitHub Pages from auto-building.

Cloudflare Pages configuration:

* Added and clarified the repository name (`mrjonstrong/website`) in the Cloudflare Pages setup section for consistency.