### PR TITLE
fix mastodon proof link

### DIFF
--- a/src/components/SocialList.astro
+++ b/src/components/SocialList.astro
@@ -10,7 +10,6 @@ import { siteConfig } from "@/site.config";
 */
 const socialLinks: {
 	friendlyName: string;
-	isWebmention?: boolean;
 	link: string;
 	name: string;
 }[] = [
@@ -21,7 +20,6 @@ const socialLinks: {
 	},
 	{
 		friendlyName: "Mastodon",
-		isWebmention: true,
 		link: siteConfig.mastodon,
 		name: "mdi:mastodon",
 	},
@@ -42,12 +40,12 @@ const socialLinks: {
 	<p>Find me on</p>
 	<ul class="flex flex-1 items-center gap-x-2 sm:flex-initial">
 		{
-			socialLinks.map(({ friendlyName, isWebmention, link, name }) => (
+			socialLinks.map(({ friendlyName, link, name }) => (
 				<li class="flex">
 					<a
 						class="hover:text-link inline-block"
 						href={link}
-						rel={["noreferrer", ...(isWebmention ? ["me"] : [])].join(" ")}
+						rel="noreferrer"
 						target="_blank"
 					>
 						<Icon aria-hidden="true" class="h-8 w-8" focusable="false" name={name} />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -38,7 +38,7 @@ const meta = {
 				<a
 					class="cactus-link inline-block"
 					href={siteConfig.mastodon}
-					rel="noreferrer me"
+					rel="noreferrer"
 					target="_blank">Mastodon</a
 				>
 			</li>


### PR DESCRIPTION
This pull request simplifies how social links are handled by removing the `isWebmention` property from the `socialLinks` array and standardizing the `rel` attribute for social links. This makes the code easier to maintain and ensures consistency in how external links are rendered.

Social link data model simplification:
* Removed the optional `isWebmention` property from the `socialLinks` array in `src/components/SocialList.astro`, streamlining the data structure.
* Removed the `isWebmention: true` entry for Mastodon from the `socialLinks` array.

Rendering consistency improvements:
* Updated the mapping of `socialLinks` so that only `rel="noreferrer"` is used for all social links, removing conditional logic for webmention support.
* Changed the Mastodon link on the About page to use `rel="noreferrer"` instead of `rel="noreferrer me"`, ensuring consistent handling of external links.