### PR TITLE
Bump pnpm/action-setup to v6.0.0 with standalone mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        with:
+          standalone: true
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
## Summary

- Bumps `pnpm/action-setup` from v4.4.0 back to v6.0.0 in ci.yml
- Adds `standalone: true` to use `@pnpm/exe` instead of the npm-ci bootstrap + self-update flow that was causing failures

## Context

v6.0.0 completely changed how pnpm is installed — from a bundled binary to bootstrapping via `npm ci` then `pnpm self-update`. This caused `pnpm install --frozen-lockfile` to fail in CI. Using `standalone: true` installs `@pnpm/exe` (a Node.js-bundled pnpm package) which avoids the problematic bootstrap flow.

## Release notes (v4.4.0 → v6.0.0)

- **v4.4.0** → Node.js 24 runtime
- **v5.0.0** → Node.js 24 runtime (major bump)
- **v6.0.0** → Added pnpm v11 support, replaced bundled binary with npm-ci bootstrap, added `standalone` input, improved Windows compatibility, added `devEngines.packageManager` fallback

## Test plan

- [x] CI Check & Build passes with v6.0.0 + standalone mode
- [ ] If standalone doesn't work, will try without standalone but with audit-mode harden-runner to capture the blocked endpoint

https://claude.ai/code/session_01WxxNyo4q6J3zJRpb67fXVF