### PR TITLE
Bump pnpm/action-setup to v6.0.0 with standalone installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        with:
+          standalone: true
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
This pull request updates the CI workflow to use a newer version of the `pnpm/action-setup` GitHub Action and enables standalone mode for pnpm installation.

Dependency and workflow updates:

* Updated `pnpm/action-setup` from version 4.4.0 to 6.0.0 in `.github/workflows/ci.yml` and enabled the `standalone` option for improved installation reliability.