### PR TITLE
Clean up documentation and fix capitalization

### DIFF
--- a/src/content/post/OSCP.md
+++ b/src/content/post/OSCP.md
@@ -153,8 +153,6 @@ Cheat sheets and other useful links (needs tiding up and moving to another page)
 
 <https://github.com/xmendez/wfuzz>
 
-<https://pentestmonkey.net/category/cheat-sheet>
-
 Credit goes to the below links where I gathered most of the sources:
 
 Prep guide for Offsec's PWK

--- a/src/content/post/Secure-your-messaging-apps.md
+++ b/src/content/post/Secure-your-messaging-apps.md
@@ -11,7 +11,7 @@ These aren't just some mythical things not to worry yourself about because they 
 
 ## Why is it important?
 
-A well known journalist had their signal account compromised. This could have been avoided had they enabled registration lock. [How a Third-Party SMS Service Was Used to Take Over Signal Accounts](https://www.vice.com/en/article/how-a-third-party-sms-service-was-used-to-take-over-signal-accounts/)
+A well known journalist had their Signal account compromised. This could have been avoided had they enabled registration lock. [How a Third-Party SMS Service Was Used to Take Over Signal Accounts](https://www.vice.com/en/article/how-a-third-party-sms-service-was-used-to-take-over-signal-accounts/)
 
 ### Signal
 


### PR DESCRIPTION
## Summary
Minor documentation cleanup and formatting fixes across two content files.

## Key Changes
- Removed outdated pentestmonkey.net cheat sheet link from OSCP.md
- Fixed capitalization of "Signal" in Secure-your-messaging-apps.md for consistency with the app's proper name

## Details
These are housekeeping changes to improve documentation quality:
- The pentestmonkey link removal appears to be part of a broader cleanup effort mentioned in the OSCP.md comments about tidying up and reorganizing cheat sheet references
- The Signal capitalization change ensures proper branding throughout the messaging apps security guide

https://claude.ai/code/session_01D6DPYxQHNwozFpxRkYTFXX