### PR TITLE
ci: add ghcr.io endpoints to trivy harden-runner allowlist

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,8 +43,10 @@ jobs:
             api.github.com:443
             check.trivy.dev:443
             get.trivy.dev:443
+            ghcr.io:443
             github.com:443
             mirror.gcr.io:443
+            pkg-containers.githubusercontent.com:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
db-repository points to ghcr.io/aquasecurity/trivy-db:2 so Trivy pulls its DB from GHCR, but ghcr.io:443 and pkg-containers.githubusercontent.com:443 (the CDN for GHCR blob layers) were missing from the egress allowlist.

https://claude.ai/code/session_017PtoFKaEjDnth5JMMP2ZuX