### PR TITLE
fix(ci): allow release-assets.githubusercontent.com in Lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -33,6 +33,7 @@ jobs:
             jonathanstrong.org:443
             mtalk.google.com:5228
             registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
             safebrowsingohttpgateway.googleapis.com:443
             www.google.com:443
 


### PR DESCRIPTION
## Problem

The scheduled **Lighthouse** workflow ([`lighthouse.yml`](https://github.com/mrjonstrong/website/blob/main/.github/workflows/lighthouse.yml)) has been failing for a while. Each run dies in under a minute at the **Setup Node** step.

The cause is visible in the `step-security/harden-runner` log:

```
domain not allowed: release-assets.githubusercontent.com.
ip address dropped: 54.185.253.63
... endpoint called ... release-assets.githubusercontent.com ... process: node
```

The workflow runs harden-runner with `egress-policy: block`. Because `.nvmrc` pins a specific Node version (`22.19`), `actions/setup-node` downloads the distribution from the `actions/node-versions` GitHub release, whose assets are served from **`release-assets.githubusercontent.com`**. That domain was missing from this workflow's allowlist, so the download was blocked and the step failed.

GitHub migrated release-asset hosting to this domain; the allowlist was never updated. `ci.yml` already allows `release-assets.githubusercontent.com:443`, which is why CI passes while Lighthouse fails — confirming the diagnosis.

## Fix

Add the missing endpoint to the harden-runner allowlist, matching the working `ci.yml`:

```yaml
            registry.npmjs.org:443
            release-assets.githubusercontent.com:443   # ← added
            safebrowsingohttpgateway.googleapis.com:443
```

## Testing

After merge, the fix can be verified via the workflow's `workflow_dispatch` trigger. Note the `schedule` trigger runs off the default branch, so this needs to reach `main` to restore the scheduled runs.

https://claude.ai/code/session_01FfcFyCjwzWkxeGKExamiL8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfcFyCjwzWkxeGKExamiL8)_