### PR TITLE
Add social link notes for LinkedIn and Twitter

### DIFF
--- a/src/components/SocialList.astro
+++ b/src/components/SocialList.astro
@@ -12,6 +12,7 @@ const socialLinks: {
 	friendlyName: string;
 	link: string;
 	name: string;
+	note?: string;
 }[] = [
 	{
 		friendlyName: "Bluesky",
@@ -37,6 +38,7 @@ const socialLinks: {
 		friendlyName: "LinkedIn",
 		link: "https://www.linkedin.com/in/mrjonstrong/",
 		name: "mdi:linkedin",
+		note: "I only connect with people I know",
 	},
 ];
 ---
@@ -45,19 +47,29 @@ const socialLinks: {
 	<p>Find me on</p>
 	<ul class="flex flex-1 items-center gap-x-2 sm:flex-initial">
 		{
-			socialLinks.map(({ friendlyName, link, name }) => (
+			socialLinks.map(({ friendlyName, link, name, note }) => (
 				<li class="flex">
 					<a
 						class="hover:text-link inline-block"
 						href={link}
 						rel="noreferrer"
 						target="_blank"
+						title={note ? `${friendlyName} — ${note}` : friendlyName}
 					>
 						<Icon aria-hidden="true" class="h-8 w-8" focusable="false" name={name} />
-						<span class="sr-only">{friendlyName}</span>
+						<span class="sr-only">{note ? `${friendlyName} (${note})` : friendlyName}</span>
 					</a>
 				</li>
 			))
 		}
 	</ul>
 </div>
+{
+	socialLinks
+		.filter(({ note }) => note)
+		.map(({ friendlyName, note }) => (
+			<p class="text-gray-500 mt-1 text-sm italic">
+				{friendlyName}: {note}
+			</p>
+		))
+}

--- a/src/components/SocialList.astro
+++ b/src/components/SocialList.astro
@@ -66,8 +66,10 @@ const socialLinks: {
 	{
 		socialLinks
 			.filter(({ note }) => note)
-			.map(({ note }) => (
-				<span class="text-gray-500 text-sm italic">({note})</span>
+			.map(({ friendlyName, note }) => (
+				<span class="text-gray-500 text-sm italic">
+					On {friendlyName}, {note}
+				</span>
 			))
 	}
 </div>

--- a/src/components/SocialList.astro
+++ b/src/components/SocialList.astro
@@ -63,13 +63,11 @@ const socialLinks: {
 			))
 		}
 	</ul>
+	{
+		socialLinks
+			.filter(({ note }) => note)
+			.map(({ note }) => (
+				<span class="text-gray-500 text-sm italic">({note})</span>
+			))
+	}
 </div>
-{
-	socialLinks
-		.filter(({ note }) => note)
-		.map(({ friendlyName, note }) => (
-			<p class="text-gray-500 mt-1 text-sm italic">
-				{friendlyName}: {note}
-			</p>
-		))
-}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -48,6 +48,7 @@ const meta = {
 				<a class="cactus-link inline-block" href="https://twitter.com/mrjonstrong" rel="noopener noreferrer" target="_blank"
 					>Twitter</a
 				>
+				(no longer active — find me on Bluesky or Mastodon instead)
 			</li>
 		</ul>
 	</div>


### PR DESCRIPTION
## Summary

Adds short clarifying notes next to a couple of social links.

**Front page (`src/components/SocialList.astro`)**
- The "Find me on" row now shows an inline note after the icons: _(I only connect with people I know)_ for LinkedIn.
- Implemented via an optional `note` field on the social links data, so any link can carry one. The note also feeds the LinkedIn icon's hover tooltip (`title`) and screen-reader label for accessibility.

**About page (`src/pages/about.astro`)**
- Notes that Twitter is no longer active and points readers to Bluesky or Mastodon instead, matching the existing parenthetical style used for the LinkedIn entry.

## Testing
- `pnpm check` — 0 errors
- `pnpm build` — succeeds, CSP hash check passes

https://claude.ai/code/session_01YJWDPaoixdWqD9RpwFiEQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJWDPaoixdWqD9RpwFiEQS)_